### PR TITLE
Fix compilation on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build
 SOURCES		:=	source source/libkhax
 DATA		:=	data
+PAYLOAD		:=	arm9payload
 INCLUDES	:=	include
 APP_TITLE	:=	miniPasta
 APP_DESCRIPTION :=	Simple, safe, no-firmlaunch Pasta
@@ -130,6 +131,8 @@ $(BUILD):
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).smdh $(TARGET).elf
+	@rm -fr $(DATA)
+	@$(MAKE) --no-print-directory -C $(PAYLOAD) clean
 
 
 #---------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,15 @@ else
 	export APP_ICON := $(TOPDIR)/$(ICON)
 endif
 
-.PHONY: $(BUILD) clean all
+.PHONY: $(PAYLOAD) $(BUILD) clean all
 
 #---------------------------------------------------------------------------------
-all: $(BUILD)
+all: $(PAYLOAD).bin $(BUILD)
+
+$(PAYLOAD).bin:
+	@make --no-print-directory -C $(PAYLOAD) -f $(CURDIR)/$(PAYLOAD)/Makefile
+	@[ -d $(DATA) ] || mkdir -p $(DATA)
+	@cp $(PAYLOAD)/$(PAYLOAD).bin $(DATA)
 
 $(BUILD):
 	@echo $(SFILES)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ export DEPSDIR	:=	$(CURDIR)/$(BUILD)
 CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
 CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
 SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
-BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*))) $(PAYLOAD).bin
 
 #---------------------------------------------------------------------------------
 # use CXX for linking C++ projects, CC for standard C

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,0 @@
-cd arm9payload
-make
-cd ..
-md data
-cp arm9payload/arm9payload.bin data
-make
-pause

--- a/clean.bat
+++ b/clean.bat
@@ -1,5 +1,0 @@
-make clean
-rm data/arm9payload.bin
-cd ARM9payload
-make clean
-pause


### PR DESCRIPTION
This fixes the compile for me on Linux.  I moved all of the logic from clean.bat and build.bat into the Makefile.

I have no idea if this will work or not on Windows.  If you don't feel like testing the compile feel free to reject the pull and I will just keep these changes locally :)

Tested and booted once on o3DS 9.2
